### PR TITLE
Change Homepage to the plugins page on GitHub.

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -2,10 +2,10 @@
     "name": "ftp-sync",
     "title": "FTP-Sync",
     "description": "FTP upload for Brackets",
-    "homepage": "https://github.com/timburgess",
+    "homepage": "https://github.com/timburgess/brackets-ftp-sync",
     "version": "1.0.5",
     "author": "Tim Burgess (https://github.com/timburgess)",
     "engines": {
-        "brackets": ">=0.36.0"
+    "brackets": ">=0.36.0"
     }
 }


### PR DESCRIPTION
Instead of the authors page, typically that is what i want when i click more info… on a extension. I'm not used to seeing two package.json in a repository, do i need to contribute a homepage to the other one as well?
